### PR TITLE
Switch to the default mode when exiting the last client

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -123,6 +123,12 @@ local function init(args)
         keypressed_callback = grabkey
     }
 
+    client.connect_signal("unmanage", function(c)
+        if #awful.screen.focused().clients == 0 and mode_box:get_text() == args.stop_name then
+            startmode(args.default_mode)
+        end
+    end)
+
     modes = process_modes(args.modes, args.stop_name)
     startmode(args.default_mode)
 end


### PR DESCRIPTION
if the last active client on a screen is closed and the current mode is
insert, switch back to the default mode.